### PR TITLE
Use standard ProjectReference instead of hacks to build generated code

### DIFF
--- a/MonoMac.sln
+++ b/MonoMac.sln
@@ -1,10 +1,7 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoMac", "src\MonoMac.csproj", "{2DD23346-B755-4D8C-A0C4-4FABD8F38F5E}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "core", "src\core.csproj", "{F8156179-CC50-485B-BA01-7D97D3FEE2BC}"
-EndProject
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29709.97
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{78756412-5D1F-4838-A1C9-B0FA95D3441E}"
 	ProjectSection(SolutionItems) = preProject
 		src\Directory.Build.props = src\Directory.Build.props
@@ -12,49 +9,41 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{78756412
 		src\Shared.props = src\Shared.props
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "generator", "src\generator.csproj", "{F1D41295-E97A-420F-85AC-FA154F4E8D07}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "core", "src\core.csproj", "{5D93C1F0-6966-4D4E-8BA9-9789B948A996}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "bmac", "src\bmac.csproj", "{11C18A28-7244-4CBF-95AE-4986B9650081}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "generator", "src\generator.csproj", "{9FC9607C-8CC9-4F1C-BFE6-F85E14EB7D45}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "bmac", "src\bmac.csproj", "{957C71B9-80B4-4FAC-97DC-98798110486D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonoMac", "src\MonoMac.csproj", "{689562B1-8F5D-406F-8A79-41E1CF248E11}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x64 = Debug|x64
-		Release|x64 = Release|x64
-		Debug|x86 = Debug|x86
-		Release|x86 = Release|x86
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{2DD23346-B755-4D8C-A0C4-4FABD8F38F5E}.Release|x86.ActiveCfg = Release|x86
-		{2DD23346-B755-4D8C-A0C4-4FABD8F38F5E}.Release|x86.Build.0 = Release|x86
-		{2DD23346-B755-4D8C-A0C4-4FABD8F38F5E}.Debug|x86.ActiveCfg = Debug|x86
-		{2DD23346-B755-4D8C-A0C4-4FABD8F38F5E}.Debug|x86.Build.0 = Debug|x86
-		{2DD23346-B755-4D8C-A0C4-4FABD8F38F5E}.Debug|x64.ActiveCfg = Debug|x64
-		{2DD23346-B755-4D8C-A0C4-4FABD8F38F5E}.Debug|x64.Build.0 = Debug|x64
-		{2DD23346-B755-4D8C-A0C4-4FABD8F38F5E}.Release|x64.ActiveCfg = Release|x64
-		{2DD23346-B755-4D8C-A0C4-4FABD8F38F5E}.Release|x64.Build.0 = Release|x64
-		{F8156179-CC50-485B-BA01-7D97D3FEE2BC}.Release|x86.ActiveCfg = Release|x86
-		{F8156179-CC50-485B-BA01-7D97D3FEE2BC}.Release|x86.Build.0 = Release|x86
-		{F8156179-CC50-485B-BA01-7D97D3FEE2BC}.Debug|x86.ActiveCfg = Debug|x86
-		{F8156179-CC50-485B-BA01-7D97D3FEE2BC}.Debug|x86.Build.0 = Debug|x86
-		{F8156179-CC50-485B-BA01-7D97D3FEE2BC}.Debug|x64.ActiveCfg = Debug|x64
-		{F8156179-CC50-485B-BA01-7D97D3FEE2BC}.Debug|x64.Build.0 = Debug|x64
-		{F8156179-CC50-485B-BA01-7D97D3FEE2BC}.Release|x64.ActiveCfg = Release|x64
-		{F8156179-CC50-485B-BA01-7D97D3FEE2BC}.Release|x64.Build.0 = Release|x64
-		{F1D41295-E97A-420F-85AC-FA154F4E8D07}.Release|x86.ActiveCfg = Release|x86
-		{F1D41295-E97A-420F-85AC-FA154F4E8D07}.Release|x86.Build.0 = Release|x86
-		{F1D41295-E97A-420F-85AC-FA154F4E8D07}.Debug|x86.ActiveCfg = Debug|x86
-		{F1D41295-E97A-420F-85AC-FA154F4E8D07}.Debug|x86.Build.0 = Debug|x86
-		{F1D41295-E97A-420F-85AC-FA154F4E8D07}.Debug|x64.ActiveCfg = Debug|x64
-		{F1D41295-E97A-420F-85AC-FA154F4E8D07}.Debug|x64.Build.0 = Debug|x64
-		{F1D41295-E97A-420F-85AC-FA154F4E8D07}.Release|x64.ActiveCfg = Release|x64
-		{F1D41295-E97A-420F-85AC-FA154F4E8D07}.Release|x64.Build.0 = Release|x64
-		{11C18A28-7244-4CBF-95AE-4986B9650081}.Release|x86.ActiveCfg = Release|x86
-		{11C18A28-7244-4CBF-95AE-4986B9650081}.Release|x86.Build.0 = Release|x86
-		{11C18A28-7244-4CBF-95AE-4986B9650081}.Debug|x86.ActiveCfg = Debug|x86
-		{11C18A28-7244-4CBF-95AE-4986B9650081}.Debug|x86.Build.0 = Debug|x86
-		{11C18A28-7244-4CBF-95AE-4986B9650081}.Debug|x64.ActiveCfg = Debug|x64
-		{11C18A28-7244-4CBF-95AE-4986B9650081}.Debug|x64.Build.0 = Debug|x64
-		{11C18A28-7244-4CBF-95AE-4986B9650081}.Release|x64.ActiveCfg = Release|x64
-		{11C18A28-7244-4CBF-95AE-4986B9650081}.Release|x64.Build.0 = Release|x64
+		{5D93C1F0-6966-4D4E-8BA9-9789B948A996}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5D93C1F0-6966-4D4E-8BA9-9789B948A996}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D93C1F0-6966-4D4E-8BA9-9789B948A996}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5D93C1F0-6966-4D4E-8BA9-9789B948A996}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9FC9607C-8CC9-4F1C-BFE6-F85E14EB7D45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9FC9607C-8CC9-4F1C-BFE6-F85E14EB7D45}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9FC9607C-8CC9-4F1C-BFE6-F85E14EB7D45}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9FC9607C-8CC9-4F1C-BFE6-F85E14EB7D45}.Release|Any CPU.Build.0 = Release|Any CPU
+		{957C71B9-80B4-4FAC-97DC-98798110486D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{957C71B9-80B4-4FAC-97DC-98798110486D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{957C71B9-80B4-4FAC-97DC-98798110486D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{957C71B9-80B4-4FAC-97DC-98798110486D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{689562B1-8F5D-406F-8A79-41E1CF248E11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{689562B1-8F5D-406F-8A79-41E1CF248E11}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{689562B1-8F5D-406F-8A79-41E1CF248E11}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{689562B1-8F5D-406F-8A79-41E1CF248E11}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {EB2AE0C9-B007-402B-BF45-A44E32C4D1CC}
 	EndGlobalSection
 EndGlobal

--- a/src/MonoMac.csproj
+++ b/src/MonoMac.csproj
@@ -8,6 +8,7 @@
     <Version>0.0.1</Version>
     <EnableDefaultItems>False</EnableDefaultItems>
     <GeneratedOutputDir Condition="$(GeneratedOutputDir) == ''">$(ArtifactsDir)generated\$(Platform)\</GeneratedOutputDir>
+    <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
   </PropertyGroup>
   <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
@@ -29,36 +30,27 @@
     <Compile Include="@(OpenGlSource)" />
     <Compile Include="@(CFNetworkSource)" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="generator.csproj" AdditionalProperties="TargetFramework=net461">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+      <ExcludeAssets>build</ExcludeAssets>
+    </ProjectReference>
+  </ItemGroup>
   
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
   <PropertyGroup>
+    <!-- needs to be after targets as it's obliterated currently (this will be fixed in the future)-->
     <CoreCompileDependsOn>IncludeGeneratedSource;$(CoreCompileDependsOn)</CoreCompileDependsOn>
   </PropertyGroup>
   
-  <Target Name="IncludeGeneratedSource" DependsOnTargets="GenerateApiSource" BeforeTargets="BeforeBuild">
+  <Target Name="IncludeGeneratedSource" BeforeTargets="BeforeBuild">
     <!-- include generated code in output -->
     <ItemGroup>
       <Compile Include="$(GeneratedOutputDir)**\*.cs" />
     </ItemGroup>
    </Target>
   
-  <Target Name="GenerateApiSource" Inputs="$(MSBuildProjectFile)" Outputs="$(GeneratedOutputDir)generated_sources ">
-    <PropertyGroup>
-      <GeneratorBuildProperties>BaseDefines=$(BaseDefines.Replace(";", "%3b"))</GeneratorBuildProperties>
-      <GeneratorBuildProperties>$(GeneratorBuildProperties);Configuration=$(Configuration)</GeneratorBuildProperties>
-      <GeneratorBuildProperties>$(GeneratorBuildProperties);BaseNamespace=MonoMac.ObjCRuntime</GeneratorBuildProperties>
-      <GenIgnoreProperties>TargetFramework;PlatformTarget</GenIgnoreProperties>
-    </PropertyGroup>
-    
-    <ItemGroup>
-      <GeneratorProjects Include="core.csproj" />
-      <GeneratorProjects Include="generator.csproj" />
-    </ItemGroup>
-    
-    <!-- build generator and core apis (if needed) -->
-    <MSBuild Projects="@(GeneratorProjects)" Targets="Build" Properties="$(GeneratorBuildProperties)" TargetAndPropertyListSeparators="%3b" RemoveProperties="$(GenIgnoreProperties)" />
-
-  </Target>
-  
-  </Project>
+</Project>

--- a/src/bmac.csproj
+++ b/src/bmac.csproj
@@ -6,17 +6,9 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <EnableDefaultItems>False</EnableDefaultItems>
     <GeneratedOutputDir>$(ArtifactsDir)generated\</GeneratedOutputDir>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="$(Platform) == 'x64'">
-    <PlatformTarget>x64</PlatformTarget>
     <BaseDefines Condition="$(BaseDefines) == ''">MONOMAC;MAC64</BaseDefines>
   </PropertyGroup>
-  <PropertyGroup Condition="$(Platform) == 'x86'">
-    <PlatformTarget>x86</PlatformTarget>
-    <BaseDefines Condition="$(BaseDefines) == ''">MONOMAC</BaseDefines>
-  </PropertyGroup>
-  
+
   <PropertyGroup>
     <DefineConstants>$(BaseDefines);GENERATOR;MONOMAC_BOOTSTRAP</DefineConstants>
   </PropertyGroup>

--- a/src/generator.cs
+++ b/src/generator.cs
@@ -2130,7 +2130,7 @@ public class Generator {
 	{
 		for (int i=0; i < tabs; i++)
 			sw.Write ('\t');
-		//sw.WriteLine ("[CompilerGenerated]");
+		sw.WriteLine ("[CompilerGenerated]");
 	}
 	
 	public void print_generated_code ()


### PR DESCRIPTION
- Use SkipGetTargetFrameworkProperties and ReferenceOutputAssembly so it doesn't complain about frameworks
- Add [CompilerGenerated] back to methods
- Fix .sln for VS 2019